### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,22 +11,22 @@ Parallel	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin			KEYWORD2
-write			KEYWORD2
-read			KEYWORD2
+begin	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
 setAddressSetupTiming	KEYWORD2
-setPulseTiming		KEYWORD2
-setCycleTiming		KEYWORD2
-setMode			KEYWORD2
-getAddress		KEYWORD2
+setPulseTiming	KEYWORD2
+setCycleTiming	KEYWORD2
+setMode	KEYWORD2
+getAddress	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-PARALLEL_CS_0		LITERAL1
-PARALLEL_CS_1		LITERAL1
-PARALLEL_CS_3		LITERAL1
+PARALLEL_CS_0	LITERAL1
+PARALLEL_CS_1	LITERAL1
+PARALLEL_CS_3	LITERAL1
 PARALLEL_CS_NONE	LITERAL1
 
 READ_MODE_NCS_CTRL	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords